### PR TITLE
Better performance of bottomupNoBridges by avoiding the triggering of ClassCastException

### DIFF
--- a/core/src/main/scala/org/bitbucket/inkytonik/kiama/relation/Tree.scala
+++ b/core/src/main/scala/org/bitbucket/inkytonik/kiama/relation/Tree.scala
@@ -112,7 +112,7 @@ class Tree[T <: AnyRef with Product, +R <: T](val originalRoot : R, shape : Tree
      * A version of `bottomup` that doesn't traverse bridges.
      */
     def bottomupNoBridges(s : Strategy) : Strategy =
-        rule[Bridge[_]] { case b => b } <+
+        rule[Any] { case b : Bridge[_] => b } <+
             (all(bottomupNoBridges(s)) <* s)
 
     /**

--- a/core/src/main/scala/org/bitbucket/inkytonik/kiama/rewriting/Cloner.scala
+++ b/core/src/main/scala/org/bitbucket/inkytonik/kiama/rewriting/Cloner.scala
@@ -29,8 +29,8 @@ trait Cloner {
     def deepclone[T <: Product](t : T) : T = {
 
         val deepcloner =
-            everywherebu(rule[T] {
-                case n if isLeaf(n) =>
+            everywherebu(rule[Any] {
+                case n : Product if isLeaf(n) =>
                     copy(n)
             })
 
@@ -55,8 +55,8 @@ trait Cloner {
         val seen = makeIdMemoiser[Product, Boolean]()
 
         val lazycloner =
-            bu(rule[T] {
-                case n if isLeaf(n) =>
+            bu(rule[Any] {
+                case n : Product if isLeaf(n) =>
                     if (seen.getOrDefault(n, false))
                         copy(n)
                     else {


### PR DESCRIPTION
from https://github.com/inkytonik/kiama/pull/35
> Hello.
> 
> We have been profiling our application, which utilizes Kiama, and have observed large amounts of `ClassCastException` errors when it processes fairly large trees. These errors originate from strategies with the following (common) shape:
> 
> ```scala
> everywhere(rule[Exp] { case BinaryExp(...) => ... ; case UnaryExp(...) => ... })
> ```
> 
> We understand the presence of `ClassCastException` is part of the design as it is explicitly handled in several places as an indication that a strategy didn't apply. Nevertheless, the performance of the tree processing code significantly improved after rewriting these strategies against the `Any` type, since this doesn't trigger a `ClassCastException` when passing through nodes that aren't `Exp`.
> 
> ```scala
> // now use Any
> everywhere(rule[Any] { case BinaryExp(...) => ... ; ...})
> ```
> 
> In our current profiling info, the next couple of places where the exception is thrown are `bottomupNoBridges` and `Cloner.deepclone`.
> 
> If patching `bottomupNoBridges` like in this PR, there's again a significant speedup. I can provide some numbers, but if there's any benchmark you'd prefer us to run, please let us know.
> 
> Flagging a strategy with the `Any` type isn't a pattern one sees in Kiama's examples, but it appears to be an effective way to improve performance. We're curious to get your comments/feedback on that.
> 
> Many thanks.

